### PR TITLE
[하영-2월1주차 문제2] 60분 전

### DIFF
--- a/프로그래머스/숫자 블록/hayoung.py
+++ b/프로그래머스/숫자 블록/hayoung.py
@@ -1,0 +1,20 @@
+def max_factor(n):
+    import math
+
+    for i in range(2, int(math.sqrt(n)) + 1):
+        if n % i == 0:
+            prime_number = n / i
+            return prime_number
+
+    return 0
+
+
+def solution(begin, end):
+    li = [1 for _ in range(end - begin + 1)]
+    if begin == 1:
+        li[0] = 1
+
+    for i in range(begin, end + 1):
+# 현재 (인덱스+1)이...
+# 1) 소수라면 1 (<- 리스트 초기화를 1로 했으므로 따로 작업 x)
+# 2) 소수가 아니라면 자기 자신을 제외한 가장 큰 인수를 저장

--- a/프로그래머스/숫자 블록/hayoung.py
+++ b/프로그래머스/숫자 블록/hayoung.py
@@ -3,8 +3,8 @@ def max_factor(n):
 
     for i in range(2, int(math.sqrt(n)) + 1):
         if n % i == 0:
-            prime_number = n / i
-            return prime_number
+            factor = int(n / i)
+            return factor
 
     return 0
 
@@ -12,9 +12,14 @@ def max_factor(n):
 def solution(begin, end):
     li = [1 for _ in range(end - begin + 1)]
     if begin == 1:
-        li[0] = 1
+        li[0] = 0
 
     for i in range(begin, end + 1):
-# 현재 (인덱스+1)이...
-# 1) 소수라면 1 (<- 리스트 초기화를 1로 했으므로 따로 작업 x)
-# 2) 소수가 아니라면 자기 자신을 제외한 가장 큰 인수를 저장
+        # 현재 (인덱스+1)이...
+        # 1) 소수라면 1 (<- 리스트 초기화를 1로 했으므로 따로 작업 x)
+        # 2) 소수가 아니라면 자기 자신을 제외한 가장 큰 인수를 저장
+        factor = max_factor(i)
+        if factor:
+            li[i - begin] = factor
+
+    return li

--- a/프로그래머스/숫자 블록/hayoung.py
+++ b/프로그래머스/숫자 블록/hayoung.py
@@ -3,8 +3,10 @@ def max_factor(n):
 
     for i in range(2, int(math.sqrt(n)) + 1):
         if n % i == 0:
-            factor = int(n / i)
-            return factor
+            max_factor = int(n / i)
+            # 포인트) 도로 길이는 최대 10억이지만 블록 수가 "최대 1천만"이므로, 1천만을 넘지 않는 최대 약수를 구한다.
+            if max_factor <= 10000000:
+                return max_factor
 
     return 0
 
@@ -22,4 +24,4 @@ def solution(begin, end):
         if factor:
             li[i - begin] = factor
 
-    return li
+    return li            


### PR DESCRIPTION
**최대 약수를 구하는 로직 및 예외처리**
---
- 처음엔 (본인을 제외한) 최대 약수를 빠르게 구하기 위해서 **range 2 ~ 제곱근(본인)** 의 값과 나누어 떨어지는 몫을 최대 약수로 설정함
    - 그러나 풀이만 맞고 효율성에서 **실패**로 뜸
- 틀린 원인이 시간 초과가 아닌 실패로 뜸 -> 현재 (도로)번째 숫자가 갖는 **최대약수가 블록의 최댓값보다 큰 경우 발생**
-> 따라서 range 2 ~ 제곱근(본인) 의 값과 **나누어 떨어지는 몫 중에서 블록의 최댓값(1천만)을 넘지 않으면서 가장 큰 수를 구하는 것으로 예외 처리 해줘야 함**