### PR TITLE
[하영 - 3월 1주차 문제] 풀이

### DIFF
--- a/프로그래머스/파괴되지 않은 건물/hayoung.py
+++ b/프로그래머스/파괴되지 않은 건물/hayoung.py
@@ -1,6 +1,8 @@
 def solution(board, skill):
-    r, c = len(board), len(board[0])
-    buildings = r * c
+    h, w = len(board), len(board[0])
+    buildings = h * w
+
+    total_sum_map = [[0 for _ in range(w + 1)] for _ in range(h)]
 
     for sk in skill:
         r1, c1, r2, c2 = tuple(sk[1:-1])
@@ -8,16 +10,20 @@ def solution(board, skill):
         # 1. 공격
         if sk[0] == 1:
             for x in range(r1, r2 + 1):
-                for y in range(c1, c2 + 1):
-                    board[x][y] -= degree
-                    if board[x][y] + degree > 0 and board[x][y] <= 0:
-                        buildings -= 1
+                total_sum_map[x][c1] -= degree
+                total_sum_map[x][c2 + 1] += degree
+
         # 2. 회복
         elif sk[0] == 2:
             for x in range(r1, r2 + 1):
-                for y in range(c1, c2 + 1):
-                    board[x][y] += degree
-                    if board[x][y] - degree <= 0 and board[x][y] > 0:
-                        buildings += 1
+                total_sum_map[x][c1] += degree
+                total_sum_map[x][c2 + 1] -= degree
+
+    for x in range(h):
+        curr_total = 0
+        for y in range(w):
+            curr_total += total_sum_map[x][y]
+            if board[x][y] + curr_total <= 0:
+                buildings -= 1
 
     return buildings

--- a/프로그래머스/파괴되지 않은 건물/hayoung.py
+++ b/프로그래머스/파괴되지 않은 건물/hayoung.py
@@ -1,29 +1,45 @@
 def solution(board, skill):
-    h, w = len(board), len(board[0])
-    buildings = h * w
-
-    total_sum_map = [[0 for _ in range(w + 1)] for _ in range(h)]
+    w, h = len(board[0]), len(board)
+    buildings = w * h
+    temp = [[0 for _ in range(w + 1)] for _ in range(h + 1)]
 
     for sk in skill:
         r1, c1, r2, c2 = tuple(sk[1:-1])
         degree = sk[-1]
-        # 1. 공격
+        # 누적합 표시 작업
+        # step 1. 공격 or 회복 시작 지점에 degree 표시
+        # step 2. 공격 or 회복 시작 행에서 마지막 지점의 뒤에 있는 지점(r1, c2+1)에 degree 표시
+        # step 3. 공격 or 회복 시작 열에서 마지막 지점의 뒤에 있는 지점(r2+1, c1)에 degree 표시
+        # step 4. 공격 or 회복 마지막 지점의 뒤에 있는 지점(r2+1, c2+1)에 degree 표시
+
+        # 공격
         if sk[0] == 1:
-            for x in range(r1, r2 + 1):
-                total_sum_map[x][c1] -= degree
-                total_sum_map[x][c2 + 1] += degree
+            temp[r1][c1] -= degree
+            temp[r1][c2 + 1] += degree
+            temp[r2 + 1][c1] += degree
+            temp[r2 + 1][c2 + 1] -= degree
 
-        # 2. 회복
+        # 회복
         elif sk[0] == 2:
-            for x in range(r1, r2 + 1):
-                total_sum_map[x][c1] += degree
-                total_sum_map[x][c2 + 1] -= degree
+            temp[r1][c1] += degree
+            temp[r1][c2 + 1] -= degree
+            temp[r2 + 1][c1] -= degree
+            temp[r2 + 1][c2 + 1] += degree
 
+    total_sum_map = [[0 for _ in range(w)] for _ in range(h)]
+
+    # 현 지점 누적합 = 현 지점 위의 누적합 + 현 지점까지의 행 누적합
     for x in range(h):
-        curr_total = 0
+        curr = 0
         for y in range(w):
-            curr_total += total_sum_map[x][y]
-            if board[x][y] + curr_total <= 0:
+            curr += temp[x][y]
+            # 첫 행은 위의 누적합이 없으므로 현 지점의 행 누적합 = 현 지점 누적합
+            if x == 0:
+                total_sum_map[x][y] = curr
+            else:
+                total_sum_map[x][y] = total_sum_map[x - 1][y] + curr
+
+            if board[x][y] + total_sum_map[x][y] <= 0:
                 buildings -= 1
 
     return buildings

--- a/프로그래머스/파괴되지 않은 건물/hayoung.py
+++ b/프로그래머스/파괴되지 않은 건물/hayoung.py
@@ -1,0 +1,23 @@
+def solution(board, skill):
+    r, c = len(board), len(board[0])
+    buildings = r * c
+
+    for sk in skill:
+        r1, c1, r2, c2 = tuple(sk[1:-1])
+        degree = sk[-1]
+        # 1. 공격
+        if sk[0] == 1:
+            for x in range(r1, r2 + 1):
+                for y in range(c1, c2 + 1):
+                    board[x][y] -= degree
+                    if board[x][y] + degree > 0 and board[x][y] <= 0:
+                        buildings -= 1
+        # 2. 회복
+        elif sk[0] == 2:
+            for x in range(r1, r2 + 1):
+                for y in range(c1, c2 + 1):
+                    board[x][y] += degree
+                    if board[x][y] - degree <= 0 and board[x][y] > 0:
+                        buildings += 1
+
+    return buildings


### PR DESCRIPTION
사용 알고리즘: 누적합
---

<삽질 기록>
1. 완전 탐색: O(N * M * len(skill))으로 매우 크기 때문에 효율성 0
2. 1시간 이상 고민하다가 막혀서 풀이법 참고 => **누적합으로 접근해야 한다!**

EX) 내구도 3인 건물이 5개로 나열되어 있다고 가정하면
[3, 3, 3, 3, 3] <- 여기에 인덱스 0부터 3까지 공격 2를 하고자 한다.

그러면 **공격&회복치 정보를 저장하는 배열 temp를 따로 관리**하여 공격 시작지점에 공격치를 기록하고, 공격 마지막 지점+1에 -(공격치)를 기록한다.
즉 temp = [0, 0, 0, 0, 0]로 초기화하고 인덱스 0~3에서 공격 2를 하므로 시작 지점인 0 인덱스에 -2(공격은 -, 회복은 +)를 기록
- temp = [-2, 0, 0, 0, 0]

마지막 공격 지점인 3에서 한 칸 뒤인 4(=3+1)에 -(-2)를 기록
- temp = [-2, 0, 0, 2, 0]

그리고 **이러한 temp를 처음부터 마지막까지 누적합을 취하면 [-2, -2, -2, 0, 0]이 된다. = 인덱스 0부터 3까지 공격 2를 가한 결과와 동일**
즉 모든 skill이 끝난 이후의 temp를 누적합을 취한 뒤 이를 건물 내구도와 합하면 모든 skill이 끝난 이후의 남은 건물 내구도를 구할 수 있다. 

3. 위의 방식으로 각 행에 대한 누적합을 구하는 방법으로 접근 => 하지만 O(M * len(skill))도 여전히 크다. 
4. (마지막) **누적합을 행에 제한하지 않고 2차원 행렬 누적합으로 접근** => 위 3의 방법과 비슷하게 누적합을 2차원 행렬로 관리

풀이)
**1. 행/열 모두 동일하게 시작 지점에 공격치/회복치 기록 & (마지막 지점+1)에 -(공격치/회복치) 기록
2. (+) 공격/회복 끝나는 지점보다 대각선 아래에 공격치/회복치 기록**

EX) 내구도가 3인 도시 3*3 행렬에서 (0, 0) ~ (1, 1) 지점을 공격 2를 한다고 가정하면
처음 temp 
0 0 0            
0 0 0         
0 0 0            

(0, 0)~(1, 1) 지점을 공격 2
-2 0 2
0 0 0
2 0 -2

**3. 위에서부터 차례대로 누적합을 구하면서, 위의 누적합 + 현재 행 누적합 = 현 지점의 최종 누적합**
3의 방법으로 진행하면 최종 누적합 total_sum은
-2 -2 0
-2 -2 0
0 0 0
이 된다. 즉 (0, 0) ~ (1, 1) 지점을 공격 2를 한 결과가 된다.

그리고 이를 원래 건물 내구도와 더한 결과가 각 건물의 현재 내구도를 나타낸다. 
따라서 시간복잡도는 O(N * M)
